### PR TITLE
add: new redirect whitelist

### DIFF
--- a/bring-cashback-redirect-whitelist.json
+++ b/bring-cashback-redirect-whitelist.json
@@ -51,5 +51,6 @@
   "*.udemy.com",
   "tatrck.com",
   "*.tradedoubler.com",
-  "ecomclik.com"
+  "ecomclik.com",
+  "*.74xz8u.net"
 ]


### PR DESCRIPTION
This pull request makes a small update to the cashback redirect whitelist by adding a new domain pattern.

- Added the domain pattern `*.74xz8u.net` to the `bring-cashback-redirect-whitelist.json` file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, data-only allowlist update; main risk is unintentionally permitting redirects to an incorrect domain if the pattern is wrong.
> 
> **Overview**
> Updates `bring-cashback-redirect-whitelist.json` to allow redirects to the new domain pattern `*.74xz8u.net` (and fixes the trailing comma on the preceding entry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54ec153038e634a55d5f3f27254178db1d638f93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->