### PR TITLE
add: whitelisted a domain

### DIFF
--- a/bring-cashback-redirect-whitelist.json
+++ b/bring-cashback-redirect-whitelist.json
@@ -52,5 +52,6 @@
   "tatrck.com",
   "*.tradedoubler.com",
   "ecomclik.com",
-  "*.74xz8u.net"
+  "*.74xz8u.net",
+  "bringweb3io.digidip.net"
 ]


### PR DESCRIPTION
This pull request makes a minor update to the `bring-cashback-redirect-whitelist.json` file by adding a new domain to the whitelist. This change expands the list of allowed redirect domains for cashback tracking.

* Added `"bringweb3io.digidip.net"` to the whitelist in `bring-cashback-redirect-whitelist.json`.